### PR TITLE
Updates from EPA WNTR Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The latest release of WNTR can be installed from PyPI or Anaconda using one of t
 
   ``conda install -c conda-forge wntr``
   
-Additional installation instructions are available at https://wntr.readthedocs.io/en/latest/installation.html.
+Additional instructions are available at https://wntr.readthedocs.io/en/latest/installation.html.
 
 Citing WNTR
 -----------------

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![TravisCI](https://travis-ci.org/sandialabs/WNTR.svg?branch=master)](https://travis-ci.org/sandialabs/WNTR)
 [![Coverage Status](https://coveralls.io/repos/github/sandialabs/WNTR/badge.svg?branch=master)](https://coveralls.io/github/sandialabs/WNTR?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/wntr/badge/?version=latest)](http://wntr.readthedocs.io/en/latest/?badge=latest)
-[![Downloads](https://pepy.tech/badge/wntr)](https://pepy.tech/project/wntr)
 
 The Water Network Tool for Resilience (WNTR) is a Python package designed to simulate and 
 analyze resilience of water distribution networks. The software includes capability to:
@@ -23,8 +22,17 @@ For more information, go to http://wntr.readthedocs.io
 Installation
 --------------
 
-The latest release of WNTR can be installed from PyPI using the command ``pip install wntr``.
-Additional instructions are available at https://wntr.readthedocs.io/en/latest/installation.html.
+The latest release of WNTR can be installed from PyPI or Anaconda using one of the following commands in a command line or PowerShell prompt.
+
+* PyPI [![version](https://img.shields.io/pypi/v/wntr.svg?maxAge=3600)](https://pypi.org/project/wntr/) [![Downloads](https://pepy.tech/badge/wntr)](https://pepy.tech/project/wntr)
+
+  ``pip install wntr``
+  
+* Anaconda [![version](https://anaconda.org/conda-forge/wntr/badges/version.svg)](https://anaconda.org/conda-forge/wntr) [![downloads](https://anaconda.org/conda-forge/wntr/badges/downloads.svg)](https://anaconda.org/conda-forge/wntr)
+
+  ``conda install -c conda-forge wntr``
+  
+Additional installation instructions are available at https://wntr.readthedocs.io/en/latest/installation.html.
 
 Citing WNTR
 -----------------

--- a/documentation/hydraulics.rst
+++ b/documentation/hydraulics.rst
@@ -255,9 +255,9 @@ where
 :math:`p` is the gauge pressure inside the pipe (Pa), 
 :math:`\alpha` is the discharge coefficient, and 
 :math:`\rho` is the density of the fluid.
-The default discharge coefficient is 0.75 (assuming turbulent flow), but 
+The default discharge coefficient is 0.75 (assuming turbulent flow) [Lamb01]_, but 
 the user can specify other values if needed.  
-The value of :math:`\alpha` is set to 0.5 (assuming large leaks out of steel pipes).  
+The value of :math:`\alpha` is set to 0.5 (assuming large leaks out of steel pipes) [Lamb01]_. 
 Leaks can be added to junctions and tanks.  
 A pipe break is modeled using a leak area large enough to drain the pipe.  
 WNTR includes methods to add leaks to any location along a pipe by splitting the pipe into two sections and adding a node. 

--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -12,10 +12,25 @@ See :ref:`requirements` and :ref:`optional_dependencies` for more information.
 WNTR can be installed as a Python package as briefly described below. 
 :ref:`detailed_instructions` are included in the following section.
 
-Users can install the latest release of WNTR from PyPI using the following command in a command line or PowerShell prompt::
+Users can install the latest release of WNTR from PyPI or Anaconda using one of the following commands in a command line or PowerShell prompt.
+
+* PyPI |pypi version|_ |pypi downloads|_ ::
 
     pip install wntr
-    
+
+* Anaconda |anaconda version|_ |anaconda downloads|_ ::
+
+    conda install -c conda-forge wntr
+
+.. |pypi version| image:: https://img.shields.io/pypi/v/wntr.svg?maxAge=3600
+.. _pypi version: https://pypi.org/project/wntr/
+.. |pypi downloads| image:: https://pepy.tech/badge/wntr
+.. _pypi downloads: https://pepy.tech/project/wntr
+.. |anaconda version| image:: https://anaconda.org/conda-forge/wntr/badges/version.svg 
+.. _anaconda version: https://anaconda.org/conda-forge/wntr
+.. |anaconda downloads| image:: https://anaconda.org/conda-forge/wntr/badges/downloads.svg
+.. _anaconda downloads: https://anaconda.org/conda-forge/wntr
+
 Developers can install the master branch of WNTR from the GitHub 
 repository using the following commands in a command line or PowerShell prompt::
 
@@ -36,7 +51,7 @@ Detailed installation instructions are included below.
 	Python can be installed on Windows, Linux, and Mac OS X operating systems.
 	WNTR requires 64-bit Python (tested on versions 3.6 and 3.7) along with several Python package dependencies.
 	Python distributions, such as Anaconda, are recommended to manage 
-	the Python environment.  Anaconda can be downloaded from https://www.anaconda.com/distribution/.  
+	the Python environment.  Anaconda can be downloaded from https://www.anaconda.com/products/individual.
 	General information on Python can be found at https://www.python.org/.
 	
 	.. note:: 
@@ -53,7 +68,7 @@ Detailed installation instructions are included below.
 	Anaconda includes the Python packages needed for WNTR, including NumPy, SciPy, NetworkX, pandas, and
 	Matplotlib.  For more information on Python package dependencies, see :ref:`requirements`.
 	If the Python installation does not include these dependencies, the user will need to install them. 
-	This is most commonly done using pip. 
+	This is most commonly done using pip or conda. 
 	
 	Anaconda also comes with Spyder, an IDE, that includes enhanced 
 	editing and debugging features along with a graphical user interface. 
@@ -85,9 +100,14 @@ Detailed installation instructions are included below.
 	The installation process differs for users and developers.  
 	Installation instructions for both types are described below.
 	
-	**For users**: Users can install WNTR using pip or by downloading a zip file and building the source code.
+	**For users**: Users can install WNTR using PyPI, Anaconda, or by downloading a zip file and building the source code.
 	
-	* **Option 1**: Users can install WNTR using pip, which is a command line software tool used to install and manage Python 
+	.. note:: 
+	   If WNTR is installed using PyPI or Anaconda (Options 1 or 2 below), the examples folder will not be downloaded.  
+	   The examples can be downloaded by going to https://github.com/USEPA/WNTR, select the "Clone or download" button and then select "Download ZIP."
+	   Uncompress the zip file using standard software tools (e.g., unzip, WinZip) and store them in a folder. 
+	   
+	* **Option 1**: Users can install WNTR from PyPI using pip, which is a command line software tool used to install and manage Python 
 	  packages.  It can be downloaded from https://pypi.python.org/pypi/pip.
 	
 	  To install WNTR using pip, open a command line or PowerShell prompt and run::
@@ -96,13 +116,24 @@ Detailed installation instructions are included below.
 	
 	  This will install the latest release of WNTR from https://pypi.python.org/pypi/wntr.  
 	
-	* **Option 2**: Users can download a zip file that includes source files and the examples folder from the US EPA GitHub organization.  
+	* **Option 2**: Users can install WNTR from Anaconda using conda, which is a command line software tool used to install and manage Python 
+	  packages.  It can be downloaded from https://www.anaconda.com/products/individual.
+	
+	  To install WNTR using conda, open a command line or PowerShell prompt and run::
+
+		  conda install -c conda-forge wntr
+	
+	  This will install the latest release of WNTR from https://anaconda.org/conda-forge/wntr.
+	  
+	* **Option 3**: Users can download a zip file that includes source files and the examples folder from the US EPA GitHub organization.  
+	  
 	  To download the master branch, go to https://github.com/USEPA/WNTR, select the "Clone or download" button and then select "Download ZIP."
 	  This downloads a zip file called WNTR-master.zip.
+	  
 	  To download a specific release, go to https://github.com/USEPA/WNTR/releases and select a zip file.
+	  
 	  Uncompress the zip file using standard software tools (e.g., unzip, WinZip) and store them in a folder. 
 	  WNTR can then be installed by running a Python script, called setup.py, that is included in the source files.
-	  
 	  To build WNTR from the source files, open a command line or PowerShell prompt from within the folder that contains the files and run:: 
 	  
 		  python setup.py install

--- a/documentation/reference.rst
+++ b/documentation/reference.rst
@@ -34,7 +34,9 @@ References
 
 .. [JCMG11] Joyner, D., Certik, O., Meurer, A., and Granger, B.E. (2012). Open source computer algebra systems, SymPy. ACM Communications in Computer Algebra, 45(4), 225-234.
 
-.. [Mcki13] McKinney W. (2013). Python for Data Analysis: Data Wrangling with Pandas, NumPy, and IPython. Sebastopal, CA: O'Reilly Media, 1 edition, 466p.
+.. [Lamb01] Lambert, A. (2001). What do we know about pressure-leakage relationships in distribution systems. Proceedings of the IWA Specialised Conference ‘System Approach to Leakage Control and Water Distribution Systems Management’, Brno, Czech Republic, 2001, May 16-18, 89-96.
+
+.. [Mcki13] McKinney, W. (2013). Python for Data Analysis: Data Wrangling with Pandas, NumPy, and IPython. Sebastopal, CA: O'Reilly Media, 1 edition, 466p.
 
 .. [NIAC09]	National Infrastructure Advisory Council (NIAC). (2009). Critical Infrastructure Resilience, Final Report and Recommendations, U.S. Department of Homeland Security, Washington, D.C., Accessed September 20, 2014. http://www.dhs.gov/xlibrary/assets/niac/niac_critical_infrastructure_resilience.pdf.
 


### PR DESCRIPTION
Note: 
The USEPA/WNTR GitHub site, https://github.com/USEPA/WNTR, does not link to Travis CI for continuous integration software testing.  
The core development team uses the sandialabs/WNTR fork, https://github.com/sandialabs/wntr, to run tests.
To submit a Pull Request to USEPA/WNTR, the developer needs to link their fork to Travis so that test results can be inspected.
If the developer does not have Travis linked to their fork, the Pull Request can be submitted to the sandialabs/WNTR fork.

